### PR TITLE
Build the functional part as a shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,6 @@ file (GLOB UTIL_HEADERS
 )
 
 add_library( fgrive SHARED
-	src/main.cc
 	src/drive/Collection.cc
 	src/drive/Drive.cc
 	src/protocol/Download.cc


### PR DESCRIPTION
Hello, I'd like to develop a GUI using your code as a solid base. Indeed, the base is so solid that I'd like to use it as a shared library.

As you might see by this pull request, I've converted your CMakeLists file to build the shared library using the three main components (drive, transport and utils) and build the "grive" binary (renamed grive_cli) linking it against the library.

It works like a charm and I thought this might be interesting for you. Feel free to ignore this PR if you're not interested in developing a shared library.
