### PR TITLE
Fix build (maybe due to GCC 4.7?) 

### DIFF
--- a/libgrive/src/http/Agent.cc
+++ b/libgrive/src/http/Agent.cc
@@ -33,6 +33,7 @@
 #include <cstring>
 #include <sstream>
 #include <streambuf>
+#include <iostream>
 
 #include <signal.h>
 


### PR DESCRIPTION
/builds/grive-git/src/grive/libgrive/src/http/Agent.cc: In function ‘void {anonymous}::CallbackInt(int)’:  
/builds/grive-git/src/grive/libgrive/src/http/Agent.cc:63:2: error: ‘cout’ is not a member of ‘std’
