### PR TITLE
sending a pull request

### DIFF
--- a/libgrive/src/drive/Resource.hh
+++ b/libgrive/src/drive/Resource.hh
@@ -77,7 +77,7 @@ public :
 	void FromRemote( const Entry& remote, const DateTime& last_sync ) ;
 	void FromLocal( const DateTime& last_sync ) ;
 	
-	void Sync( http::Agent* http, const http::Header& auth ) ;
+	void Sync( http::Agent* http, const http::Header& auth, DateTime& sync_time ) ;
 
 	// children access
 	iterator begin() const ;
@@ -125,9 +125,9 @@ private :
 	void SetState( State new_state ) ;
 
 	void Download( http::Agent* http, const fs::path& file, const http::Header& auth ) const ;
-	bool EditContent( http::Agent* http, const http::Header& auth ) ;
-	bool Create( http::Agent* http, const http::Header& auth ) ;
-	bool Upload( http::Agent* http, const std::string& link, const http::Header& auth, bool post ) ;
+	bool EditContent( http::Agent* http, const http::Header& auth, DateTime& sync_time ) ;
+	bool Create( http::Agent* http, const http::Header& auth, DateTime& sync_time ) ;
+	bool Upload( http::Agent* http, const std::string& link, const http::Header& auth, bool post, DateTime& sync_time ) ;
 	
 	void FromRemoteFolder( const Entry& remote, const DateTime& last_sync ) ;
 	void FromRemoteFile( const Entry& remote, const DateTime& last_sync ) ;
@@ -136,7 +136,7 @@ private :
 	void DeleteRemote( http::Agent* http, const http::Header& auth ) ;
 	
 	void AssignIDs( const Entry& remote ) ;
-	void SyncSelf( http::Agent* http, const http::Header& auth ) ;
+	void SyncSelf( http::Agent* http, const http::Header& auth, DateTime& sync_time ) ;
 	
 private :
 	std::string				m_name ;

--- a/libgrive/src/drive/State.cc
+++ b/libgrive/src/drive/State.cc
@@ -264,8 +264,20 @@ void State::Write( const fs::path& filename ) const
 
 void State::Sync( http::Agent *http, const http::Header& auth )
 {
-	m_res.Root()->Sync( http, auth ) ;
-	m_last_sync = DateTime::Now() ;
+	// set the last sync time from the time returned by the server for the last file synced
+	// if the sync time hasn't changed (i.e. now files have been uploaded)
+	// set the last sync time to the time on the client
+	// ideally because we compare server file times to the last sync time
+	// the last sync time would always be a server time rather than a client time
+	// TODO - WARNING - do we use the last sync time to compare to client file times
+	// need to check if this introduces a new problem
+ 	DateTime last_sync_time = m_last_sync;
+	m_res.Root()->Sync( http, auth, last_sync_time ) ;
+  	if (last_sync_time == m_last_sync) {
+    	m_last_sync = DateTime::Now();
+  	} else {
+    	m_last_sync = last_sync_time;
+  	}
 }
 
 long State::ChangeStamp() const


### PR DESCRIPTION
This should fix the "deleted file downloaded again" problem - the server time for the lastest change is not stored in State::m_last_sync instead of the client time - this makes time comparisons more useful - I haven't thoroughly that m_last_sync is not being compared elsewhere with client side times. I also removed the check for the remote changestamp as this is not appropriate - the remote file will get a changestamp when it is created as part of the upload.
