### PR TITLE
Removed linking to IBERTY_LIBRARY and added Boost to CMakeLists file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,6 @@ cmake_minimum_required(VERSION 2.8)
 # Grive version. remember to update it for every new release!
 set( GRIVE_VERSION "0.2.0" )
 
-# Actually find the boost libraries
-find_package( Boost )
-
 # common compile options
 add_definitions( -DVERSION="${GRIVE_VERSION}" )
 add_definitions( -D_FILE_OFFSET_BITS=64 )

--- a/libgrive/CMakeLists.txt
+++ b/libgrive/CMakeLists.txt
@@ -27,10 +27,11 @@ if ( BFD_FOUND )
 	
 endif ( BFD_FOUND )
 
-# Not found on my system or in any standard repos.
-#if ( IBERTY_FOUND )
-#	set( OPT_LIBS	${OPT_LIBS}	${IBERTY_LIBRARY} )
-#endif ( IBERTY_FOUND )
+if ( IBERTY_FOUND )
+	set( OPT_LIBS	${OPT_LIBS}	${IBERTY_LIBRARY} )
+else ( IBERTY_FOUND )
+  set( IBERTY_LIBRARY "" )
+endif ( IBERTY_FOUND )
 
 if ( ZLIB_FOUND )
 	set( OPT_LIBS	${OPT_LIBS}	${ZLIB_LIBRARIES} )
@@ -82,7 +83,7 @@ target_link_libraries( grive
 	${LIBGCRYPT_LIBRARIES}
 	${GDBM_LIBRARIES}
 	${Boost_LIBRARIES}
-	#${IBERTY_LIBRARY}
+	${IBERTY_LIBRARY}
 	${EXPAT_LIBRARY}
 	${OPT_LIBS}
 )


### PR DESCRIPTION
The iberty_library stuff could not be found anywhere in my repos or on my system. Compiles and runs fine without. Correct me if I'm wrong, but is this necessary? Removed it from libgrive/CMakeLists.txt .
Also, added find_package( Boost ) to ./CMakeLists.txt (which will otherwise yield an error about the boost library not being found).
