### PR TITLE
Fix grive compilation with newer binutils versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,5 +7,9 @@ set( GRIVE_VERSION "0.3.0-pre" )
 add_definitions( -DVERSION="${GRIVE_VERSION}" )
 add_definitions( -D_FILE_OFFSET_BITS=64 )
 
+# Package name and version for libraries depending on autotools
+add_definitions( -DPACKAGE="grive" )
+add_definitions( -DPACKAGE_VERSION="${GRIVE_VERSION}" )
+
 add_subdirectory( libgrive )
 add_subdirectory( grive )


### PR DESCRIPTION
Trying to compile grive with binutils 2.22.90 failed because bfd.h
required PACKAGE and PACKAGE version to be defined. Adding these
definitions to the build to fix this compile error and any issues
with future library changes that depend on autotools.
