### PR TITLE
Fix compile issue due to stale header definitions

### DIFF
--- a/libgrive/test/util/ConfigTest.hh
+++ b/libgrive/test/util/ConfigTest.hh
@@ -31,15 +31,13 @@ public :
 	ConfigTest( ) ;
 
 	CPPUNIT_TEST_SUITE( ConfigTest ) ;
-		CPPUNIT_TEST( TestInitialiseWithEmptyString ) ;
-		CPPUNIT_TEST( TestInitialiseWithString ) ;
-		CPPUNIT_TEST( TestInitialiseWithFileSystemPath ) ;
+		CPPUNIT_TEST( TestInitialiseWithNoPath ) ;
+		CPPUNIT_TEST( TestInitialiseWithPath ) ;
 	CPPUNIT_TEST_SUITE_END();
 
 private :
-  void TestInitialiseWithEmptyString( );
-  void TestInitialiseWithString( );
-  void TestInitialiseWithFileSystemPath( );
+  void TestInitialiseWithNoPath( );
+  void TestInitialiseWithPath( );
 } ;
 
 } // end of namespace


### PR DESCRIPTION
It seems like the function names in ConfigTest.cc were changed but
the corresponding names in ConfigTest.hh weren't updated, which
caused a compilation failure with g++ 4.6.3.
