### PR TITLE
Send default log to stdout instead of stderr

### DIFF
--- a/libgrive/src/util/log/DefaultLog.cc
+++ b/libgrive/src/util/log/DefaultLog.cc
@@ -25,7 +25,7 @@
 namespace gr { namespace log {
 
 DefaultLog::DefaultLog() :
-	m_log( std::cerr )
+	m_log( std::cout )
 {
 // 	Enable(log::debug,		true) ;
 // 	Enable(log::verbose,	true) ;


### PR DESCRIPTION
As requested by #131, it is indeed useful when running from cron.
