### PR TITLE
Fixed building

### DIFF
--- a/libgrive/src/bfd/SymbolInfo.cc
+++ b/libgrive/src/bfd/SymbolInfo.cc
@@ -17,6 +17,9 @@
 	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
+#define PACKAGE "grive"
+#define PACKAGE_VERSION "git"
+
 #include "SymbolInfo.hh"
 #include "Debug.hh"
 

--- a/libgrive/test/util/ConfigTest.hh
+++ b/libgrive/test/util/ConfigTest.hh
@@ -31,16 +31,14 @@ public :
 	ConfigTest( ) ;
 
 	CPPUNIT_TEST_SUITE( ConfigTest ) ;
-		CPPUNIT_TEST( TestInitialiseWithEmptyString ) ;
-		CPPUNIT_TEST( TestInitialiseWithString ) ;
-		CPPUNIT_TEST( TestInitialiseWithFileSystemPath ) ;
+		CPPUNIT_TEST( TestInitialiseWithPath ) ;
+		CPPUNIT_TEST( TestInitialiseWithNoPath ) ;
 	CPPUNIT_TEST_SUITE_END();
 
 private :
-  void TestInitialiseWithEmptyString( );
-  void TestInitialiseWithString( );
-  void TestInitialiseWithFileSystemPath( );
-} ;
+  void TestInitialiseWithNoPath( );
+  void TestInitialiseWithPath( );
+};
 
 } // end of namespace
 


### PR DESCRIPTION
Grive was failing to build on my Arch box, some problems in the ConfigTest class with depricated functions? Also added some pre-compiler macros to comply with the new binutils 'have to include config.h' rules as here:

http://stackoverflow.com/questions/11748035/binutils-bfd-h-wants-config-h-now

Builds now. 
