### PR TITLE
Fix compilation on Debian 7 i686 due to 3 missing boost::uint64_t  casts in State.cc

### DIFF
--- a/libgrive/src/drive/State.cc
+++ b/libgrive/src/drive/State.cc
@@ -248,12 +248,12 @@ void State::Read( const fs::path& filename )
 void State::Write( const fs::path& filename ) const
 {
 	Json last_sync ;
-	last_sync.Add( "sec",	Json(m_last_sync.Sec() ) );
-	last_sync.Add( "nsec",	Json(m_last_sync.NanoSec() ) );
+	last_sync.Add( "sec",	Json((boost::uint64_t) m_last_sync.Sec() ) );
+	last_sync.Add( "nsec",	Json((boost::uint64_t) m_last_sync.NanoSec() ) );
 	
 	Json result ;
 	result.Add( "last_sync", last_sync ) ;
-	result.Add( "change_stamp", Json(m_cstamp) ) ;
+	result.Add( "change_stamp", Json((boost::uint64_t) m_cstamp) ) ;
 	
 	std::ofstream fs( filename.string().c_str() ) ;
 	fs << result ;


### PR DESCRIPTION
Compilation was failing with:

Scanning dependencies of target btest
[ 83%] Building CXX object libgrive/CMakeFiles/btest.dir/test/btest/ValTest.cc.o
[ 85%] Building CXX object libgrive/CMakeFiles/btest.dir/test/btest/UnitTest.cc.o
[ 87%] Building CXX object libgrive/CMakeFiles/btest.dir/test/btest/JsonValTest.cc.o
Linking CXX executable btest
[ 87%] Built target btest
Scanning dependencies of target grive_executable
[ 89%] Building CXX object grive/CMakeFiles/grive_executable.dir/src/main.cc.o
Linking CXX executable grive
../libgrive/libgrive.a(State.cc.o): In function `gr::v1::State::Write(boost::filesystem3::path const&) const':
State.cc:(.text+0x1778): undefined reference to`gr::Json::Json<long>(long const&)'
State.cc:(.text+0x17fa): undefined reference to `gr::Json::Json<unsigned long>(unsigned long const&)'
State.cc:(.text+0x18cd): undefined reference to`gr::Json::Json<long>(long const&)'
collect2: error: ld returned 1 exit status
make[2]: **\* [grive/grive] Error 1
make[1]: **\* [grive/CMakeFiles/grive_executable.dir/all] Error 2
make: **\* [all] Error 2

Host system is:
Linux debian 3.2.0-4-686-pae #1 SMP Debian 3.2.57-3+deb7u1 i686 GNU/Linux
